### PR TITLE
feat: make key options pretty, remove outlandish key centers

### DIFF
--- a/src/components/jam/key-center-selector.tsx
+++ b/src/components/jam/key-center-selector.tsx
@@ -1,5 +1,9 @@
 import { Select } from "theme-ui";
-import { Note21 } from "../../18th-century-europe/note";
+import {
+  getAccidentalSymbol,
+  getNoteSymbol,
+} from "../../18th-century-europe/engraving";
+import { getNoteDataFromNote21, Note21 } from "../../18th-century-europe/note";
 
 export interface KeyCenterSelectorProps {
   keyCenter: Note21;
@@ -10,9 +14,23 @@ export const KeyCenterSelector: React.FC<KeyCenterSelectorProps> = ({
   keyCenter,
   setKeyCenter,
 }) => {
-  const keyCenters = Object.values(Note21).filter(
-    (value) => typeof value === "string"
-  );
+  const keyCenters = [
+    Note21.C_NATURAL,
+    Note21.D_NATURAL,
+    Note21.E_NATURAL,
+    Note21.F_NATURAL,
+    Note21.G_NATURAL,
+    Note21.A_NATURAL,
+    Note21.B_NATURAL,
+    Note21.C_FLAT,
+    Note21.C_SHARP,
+    Note21.D_FLAT,
+    Note21.E_FLAT,
+    Note21.F_SHARP,
+    Note21.G_FLAT,
+    Note21.A_FLAT,
+    Note21.B_FLAT,
+  ];
 
   return (
     <>
@@ -22,14 +40,16 @@ export const KeyCenterSelector: React.FC<KeyCenterSelectorProps> = ({
         }
         sx={{ minWidth: "80px" }}
       >
-        {keyCenters.map((key) => (
-          <option key={key} value={key}>
-            {`${key.toString().charAt(0)}${key
-              .toString()
-              .slice(1)
-              .toLowerCase()}`}
-          </option>
-        ))}
+        {keyCenters.map((key) => {
+          const data = getNoteDataFromNote21(key);
+          return (
+            <option key={key} value={Note21[key]}>
+              {`${getNoteSymbol(data.note)}${getAccidentalSymbol(
+                data.accidental
+              )}`}
+            </option>
+          );
+        })}
       </Select>
     </>
   );


### PR DESCRIPTION
- Only show the most typical key centers, not wacky stuff like B#
- Display the options as notes, not the ugly snake case strings from before