### PR TITLE
feat: implement variable chord duration

### DIFF
--- a/src/18th-century-europe/engraving.ts
+++ b/src/18th-century-europe/engraving.ts
@@ -14,6 +14,9 @@ export const ACCIDENTALS: Record<Accidental, string> = {
   [Accidental.SHARP]: "♯",
   [Accidental.FLAT]: "♭",
 };
+
+export type ChordWithDuration = { symbol: string; duration: number };
+
 /** Returns a string symbol representing a type of triad, such as `'m'`*/
 export const getTriadSymbol = (triad: Triad) => {
   return CHORD_SYMBOLS[triad];

--- a/src/components/jam/chord-chart/bar.tsx
+++ b/src/components/jam/chord-chart/bar.tsx
@@ -1,5 +1,22 @@
-import { Grid } from "theme-ui";
-
-export const Bar: React.FC = ({ children }) => {
-  return <Grid columns={4}>{children}</Grid>;
+import { Box, Grid } from "theme-ui";
+import { ChordWithDuration } from "../../../18th-century-europe/engraving";
+import { ChordSymbol } from "./chord-symbol";
+export interface BarProps {
+  chords?: ChordWithDuration[];
+}
+export const Bar: React.FC<BarProps> = ({ chords = [] }) => {
+  return (
+    <Grid columns={4}>
+      {chords.map((chord, index) => (
+        <Box
+          key={index}
+          sx={{
+            gridColumnEnd: `span ${chord.duration}`,
+          }}
+        >
+          <ChordSymbol chord={chord.symbol}></ChordSymbol>
+        </Box>
+      ))}
+    </Grid>
+  );
 };

--- a/src/components/jam/chord-chart/chart-line.tsx
+++ b/src/components/jam/chord-chart/chart-line.tsx
@@ -1,29 +1,28 @@
 import { Box } from "theme-ui";
+import { ChordWithDuration } from "../../../18th-century-europe/engraving";
 import { Bar } from "./bar";
-import { ChordSymbol } from "./chord-symbol";
+import { divideChordsIntoLists } from "./chord-chart";
 
 export interface ChartLineProps {
-  chords: string[];
+  chords: ChordWithDuration[];
 }
 
-export const ChartLine: React.FC<ChartLineProps> = ({ chords }) => (
-  <>
-    <Box sx={{ bg: "#000000", borderRadius: 2 }} />
-    <Bar>
-      <ChordSymbol chord={chords[0]} />
-    </Bar>
-    <Box sx={{ bg: "#000000", borderRadius: 2 }} />
-    <Bar>
-      <ChordSymbol chord={chords[1]} />
-    </Bar>
-    <Box sx={{ bg: "#000000", borderRadius: 2 }} />
-    <Bar>
-      <ChordSymbol chord={chords[2]} />
-    </Bar>
-    <Box sx={{ bg: "#000000", borderRadius: 2 }} />
-    <Bar>
-      <ChordSymbol chord={chords[3]} />
-    </Bar>
-    <Box sx={{ bg: "#000000", borderRadius: 2 }} />
-  </>
-);
+export const ChartLine: React.FC<ChartLineProps> = ({ chords }) => {
+  // do stuff based on duration
+
+  const chordsInBars = divideChordsIntoLists(chords, 4.0);
+
+  return (
+    <>
+      <Box sx={{ bg: "#000000", borderRadius: 2 }} />
+      <Bar chords={chordsInBars[0]} />
+      <Box sx={{ bg: "#000000", borderRadius: 2 }} />
+      <Bar chords={chordsInBars[1]} />
+      <Box sx={{ bg: "#000000", borderRadius: 2 }} />
+      <Bar chords={chordsInBars[2]} />
+      <Box sx={{ bg: "#000000", borderRadius: 2 }} />
+      <Bar chords={chordsInBars[3]} />
+      <Box sx={{ bg: "#000000", borderRadius: 2 }} />
+    </>
+  );
+};

--- a/src/components/jam/chord-chart/chord-chart.tsx
+++ b/src/components/jam/chord-chart/chord-chart.tsx
@@ -1,30 +1,69 @@
 import { Grid } from "theme-ui";
+import { ChordWithDuration } from "../../../18th-century-europe/engraving";
 import { ChartLine } from "./chart-line";
 
 export interface ChordChartProps {
-  chords: string[];
+  chords: ChordWithDuration[];
 }
 
-export const ChordChart: React.FC<ChordChartProps> = ({ chords }) => {
-  // determine how many lines we need by countin the amount of chords and comparing with multiples of four
-  // if 9 chords, we want three lines, if 1 chords, we want 1 line
-  const lines = Math.ceil(chords.length / 4.0);
+/** Split a list of chords in two; the first number of chords that fit within the specified duration, and the rest */
+export const splitChordsByDuration = (
+  chords: ChordWithDuration[],
+  duration: number
+) => {
+  const durationChords: ChordWithDuration[] = [];
+  const restChords: ChordWithDuration[] = [];
 
-  // for each line, make an array with four of the strings from the chord array
-  const chordsInLines: string[][] = [];
-  for (let i = 0; i < lines; i++) {
-    chordsInLines.push([
-      chords[0 + i * 4],
-      chords[1 + i * 4],
-      chords[2 + i * 4],
-      chords[3 + i * 4],
-    ]);
+  let sum = 0;
+
+  chords.forEach((chord) => {
+    if (sum + chord.duration > duration) {
+      restChords.push(chord);
+    } else {
+      durationChords.push(chord);
+      sum += chord.duration;
+    }
+  });
+  return { lineChords: durationChords, restChords };
+};
+
+/** Divides chords in a nested list where each sublist has a max length (number of beats)
+ * @param chords a list of chords
+ * @param lengthOfDivision the max length if each sublist
+ * @returns a list of lists of chords
+ */
+export const divideChordsIntoLists = (
+  chords: ChordWithDuration[],
+  lengthOfDivision: number
+) => {
+  const chordsInLines: ChordWithDuration[][] = [];
+
+  let restOfChords = [...chords];
+
+  while (restOfChords.length > 0) {
+    const { lineChords, restChords } = splitChordsByDuration(
+      restOfChords,
+      lengthOfDivision
+    );
+    chordsInLines.push(lineChords);
+
+    restOfChords = restChords;
   }
 
+  return chordsInLines;
+};
+export const ChordChart: React.FC<ChordChartProps> = ({ chords }) => {
+  const chordsInLines = divideChordsIntoLists(chords, 16.0);
   return (
-    <Grid columns={"1fr 50fr 1fr 50fr 1fr 50fr 1fr 50fr 1fr"}>
-      {chordsInLines.map((chords) => (
-        <ChartLine chords={chords} />
+    <Grid
+      columns={[
+        "1fr 30fr 1fr 30fr 1fr 30fr 1fr 30fr 1fr",
+        "1fr 70fr 1fr 70fr 1fr 70fr 1fr 70fr 1fr",
+      ]}
+      sx={{ gap: 1 }}
+    >
+      {chordsInLines.map((chords, index) => (
+        <ChartLine chords={chords} key={index} />
       ))}
     </Grid>
   );

--- a/src/components/jam/chord-chart/chord-symbol.tsx
+++ b/src/components/jam/chord-chart/chord-symbol.tsx
@@ -1,7 +1,7 @@
 import { Text, ThemeUIStyleObject } from "theme-ui";
 
 export interface ChordSymbolProps {
-  chord: string;
+  chord?: string;
   sx?: ThemeUIStyleObject;
 }
 export const ChordSymbol: React.FC<ChordSymbolProps> = ({ chord, sx }) => {

--- a/src/components/jam/chord-list.tsx
+++ b/src/components/jam/chord-list.tsx
@@ -1,8 +1,9 @@
 import { Box, Heading } from "theme-ui";
+import { ChordWithDuration } from "../../18th-century-europe/engraving";
 import { ChordChart } from "./chord-chart/chord-chart";
 
 export interface ChordListProps {
-  chords: string[];
+  chords: ChordWithDuration[];
 }
 
 export const ChordList: React.FC<ChordListProps> = ({ chords }) => {

--- a/src/jam.tsx
+++ b/src/jam.tsx
@@ -1,21 +1,23 @@
 import React, { useState } from "react";
 import { Box, Button, Flex, Heading, Paragraph } from "theme-ui";
+import { ChordWithDuration } from "./18th-century-europe/engraving";
 import { Mode } from "./18th-century-europe/mode";
 import { Note21 } from "./18th-century-europe/note";
 import { ChordList } from "./components/jam/chord-list";
 import { KeyCenterSelector } from "./components/jam/key-center-selector";
 import { ModeSelector } from "./components/jam/mode-selector";
-import { getNewChordWithinKey } from "./services/chord-helpers";
+import { getNewChordWithinKey, randomInteger } from "./services/chord-helpers";
 
 export const Jam: React.FC = () => {
-  const [chords, setChords] = useState<string[]>([]);
+  const [chords, setChords] = useState<ChordWithDuration[]>([]);
   const [mode, setMode] = useState<Mode>(Mode.IONIAN);
   const [keyCenter, setKeyCenter] = useState<Note21>(Note21.C_NATURAL);
 
   const addChord = () => {
-    const newChord = getNewChordWithinKey(mode, keyCenter, chords);
+    const newChord = getNewChordWithinKey(mode, keyCenter);
 
-    const newList = [...chords, newChord];
+    const withDuration = { symbol: newChord, duration: randomInteger(1, 4) };
+    const newList = [...chords, withDuration];
     setChords(newList);
   };
 

--- a/src/services/chord-helpers.ts
+++ b/src/services/chord-helpers.ts
@@ -43,11 +43,7 @@ export const generateChord = () => {
   return newChord;
 };
 
-export const getNewChordWithinKey = (
-  mode: Mode,
-  center: Note21,
-  currentChords: string[]
-) => {
+export const getNewChordWithinKey = (mode: Mode, center: Note21) => {
   const index = randomInteger(0, 6);
 
   const newChord = engraveChord(index, center, mode);


### PR DESCRIPTION
With this PR, chords can now last 1-4 beats. The behaviour of how they are divided into the bars may seem a little counter intuitive, since slots are "filled in", and bars cannot extend through barlines. We can tweak this behaviour further in the future, but I feel like the current implementation definitely adds value.

In addition, this lays the groundwork for writing more complex chord progressions than just 1 bar of this, then 1 bar of that, etc.